### PR TITLE
Define a stable module name via an Automatic-Module-Name entry in manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ algorithm](http://en.wikipedia.org/wiki/Shamir's_Secret_Sharing) over GF(256).
 </dependency>
 ```
 
+*Note: module name for Java 9+ is `com.codahale.shamir`.*
+
 ## Use the thing
 
 ```java

--- a/pom.xml
+++ b/pom.xml
@@ -58,4 +58,23 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Automatic-Module-Name>com.codahale.shamir</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>


### PR DESCRIPTION
In a Java 9+ modular application, Java turns the non-modular JARs (i.e. JARs that do not contain a module-info.java file) into a so-called automatic module, whose name is derived from the JAR's file name.
With an Automatic-Module-Name entry in the manifest file, a JAR targeting a pre Java 9 runtime  gets a "stable" name when used in a modular Java 9+ application.

For more information, see http://blog.joda.org/2017/05/java-se-9-jpms-automatic-modules.html or http://branchandbound.net/blog/java/2017/12/automatic-module-name/ 