### PR TITLE
apparent bug in tiered sharing code

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ class BuildTree {
 
     // tier 2 of the tree
     final Scheme userScheme = Scheme.of(4, 3);
-    final Map<Integer, Map<Integer, byte[]>> admins =
+    final Map<Integer, Map<Integer, byte[]>> users =
         users.entrySet()
             .stream()
             .collect(Collectors.toMap(Map.Entry::getKey, e -> userScheme.split(e.getValue())));


### PR DESCRIPTION
The variable 'admins' looks to be declared twice and the variable 'users' isn't declared. This change should fix that.