### PR TITLE
Make Scheme::join() a static method

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ class Example {
     final Scheme scheme = new Scheme(new SecureRandom(), 5, 3);
     final byte[] secret = "hello there".getBytes(StandardCharsets.UTF_8);
     final Map<Integer, byte[]> parts = scheme.split(secret);
-    final byte[] recovered = scheme.join(parts);
+    final byte[] recovered = Scheme.join(parts);
     System.out.println(new String(recovered, StandardCharsets.UTF_8));
   } 
 }

--- a/src/main/java/com/codahale/shamir/Scheme.java
+++ b/src/main/java/com/codahale/shamir/Scheme.java
@@ -95,7 +95,7 @@ public class Scheme {
    * @throws IllegalArgumentException if {@code parts} is empty or contains values of varying
    *     lengths
    */
-  public byte[] join(Map<Integer, byte[]> parts) {
+  public static byte[] join(Map<Integer, byte[]> parts) {
     checkArgument(parts.size() > 0, "No parts provided");
     final int[] lengths = parts.values().stream().mapToInt(v -> v.length).distinct().toArray();
     checkArgument(lengths.length == 1, "Varying lengths of part values");

--- a/src/test/java/com/codahale/shamir/benchmarks/Benchmarks.java
+++ b/src/test/java/com/codahale/shamir/benchmarks/Benchmarks.java
@@ -60,6 +60,6 @@ public class Benchmarks {
 
   @Benchmark
   public byte[] join() {
-    return scheme.join(parts);
+    return Scheme.join(parts);
   }
 }

--- a/src/test/java/com/codahale/shamir/perf/LoadHarness.java
+++ b/src/test/java/com/codahale/shamir/perf/LoadHarness.java
@@ -24,7 +24,7 @@ public class LoadHarness {
     final byte[] secret = new byte[10 * 1024];
     final Scheme scheme = new Scheme(new SecureRandom(), 200, 20);
     for (int i = 0; i < 100_000_000; i++) {
-      scheme.join(scheme.split(secret));
+      Scheme.join(scheme.split(secret));
     }
   }
 }

--- a/src/test/java/com/codahale/shamir/tests/SchemeTest.java
+++ b/src/test/java/com/codahale/shamir/tests/SchemeTest.java
@@ -62,7 +62,7 @@ class SchemeTest implements WithQuickTheories {
 
   @Test
   void joinEmptyParts() {
-    assertThatThrownBy(() -> new Scheme(new SecureRandom(), 3, 2).join(Collections.emptyMap()))
+    assertThatThrownBy(() -> Scheme.join(Collections.emptyMap()))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -71,8 +71,7 @@ class SchemeTest implements WithQuickTheories {
     final byte[] one = new byte[] {1};
     final byte[] two = new byte[] {1, 2};
 
-    assertThatThrownBy(
-            () -> new Scheme(new SecureRandom(), 3, 2).join(ImmutableMap.of(1, one, 2, two)))
+    assertThatThrownBy(() -> Scheme.join(ImmutableMap.of(1, one, 2, two)))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -81,7 +80,7 @@ class SchemeTest implements WithQuickTheories {
     final Scheme scheme = new Scheme(new SecureRandom(), 8, 3);
     final byte[] secret = "x".getBytes(StandardCharsets.UTF_8);
 
-    assertThat(scheme.join(scheme.split(secret))).containsExactly(secret);
+    assertThat(Scheme.join(scheme.split(secret))).containsExactly(secret);
   }
 
   @Test
@@ -89,7 +88,7 @@ class SchemeTest implements WithQuickTheories {
     final Scheme scheme = new Scheme(new SecureRandom(), 200, 3);
     final byte[] secret = "x".getBytes(StandardCharsets.UTF_8);
 
-    assertThat(scheme.join(scheme.split(secret))).containsExactly(secret);
+    assertThat(Scheme.join(scheme.split(secret))).containsExactly(secret);
   }
 
   @Test
@@ -129,6 +128,6 @@ class SchemeTest implements WithQuickTheories {
   private byte[] join(Scheme scheme, Set<Map.Entry<Integer, byte[]>> entries) {
     final Map<Integer, byte[]> m = new HashMap<>();
     entries.forEach(v -> m.put(v.getKey(), v.getValue()));
-    return scheme.join(m);
+    return Scheme.join(m);
   }
 }


### PR DESCRIPTION
This makes it clear that we do not need to instantiate a Scheme object to call join().  Otherwise users think we need to instantiate the object, along with it's parameters, which doesn't appear to be necessary